### PR TITLE
Add support for next, prev and siblings

### DIFF
--- a/examples/hackernews.graphql
+++ b/examples/hackernews.graphql
@@ -1,0 +1,15 @@
+{
+    page(url:"http://news.ycombinator.com") {
+      items: query(selector:"tr.athing") {
+        rank: text(selector:"td span.rank")
+        title: text(selector:"td.title a")
+        sitebit: text(selector:"span.comhead a")
+        url: attr(selector:"td.title a", name:"href")
+        attrs: next {
+           score: text(selector:"span.score")
+           user: text(selector:"a:eq(0)")
+           comments: text(selector:"a:eq(2)")
+        }
+      }
+    }
+  }

--- a/gdom/schema.py
+++ b/gdom/schema.py
@@ -29,7 +29,7 @@ class Node(graphene.Interface):
     parent = graphene.Field('Element',
                             description='The parent element from self')
     siblings = graphene.List('Element',
-                            description='The following sibling from self',
+                            description='The siblings elements from self',
                             selector=graphene.String())
     next = graphene.Field('Element',
                           description='The immediately following sibling from self',

--- a/gdom/schema.py
+++ b/gdom/schema.py
@@ -28,6 +28,12 @@ class Node(graphene.Interface):
                             selector=graphene.String())
     parent = graphene.Field('Element',
                             description='The parent element from self')
+    siblings = graphene.List('Element',
+                            description='The following sibling from self',
+                            selector=graphene.String())
+    next = graphene.Field('Element',
+                          description='The immediately following sibling from self',
+                          selector=graphene.String())
 
     def _query_selector(self, args):
         selector = args.get('selector')
@@ -72,6 +78,16 @@ class Node(graphene.Interface):
         if parent:
             return parent
 
+    def resolve_siblings(self, args, info):
+        selector = args.get('selector')
+        return self.nextAll(selector).items()
+
+    def resolve_next(self, args, info):
+        selector = args.get('selector')
+        n = self.nextAll(selector)
+        if n:
+            return n.eq(0)
+
 
 def get_page(page):
     return pq(page, headers={'user-agent': 'gdom'})
@@ -79,7 +95,7 @@ def get_page(page):
 
 class Document(Node):
     '''
-    The Document Type represent any web page loaded and 
+    The Document Type represent any web page loaded and
     serves as an entry point into the page content
     '''
     title = graphene.String(description='The title of the document')

--- a/gdom/schema.py
+++ b/gdom/schema.py
@@ -34,6 +34,9 @@ class Node(graphene.Interface):
     next = graphene.Field('Element',
                           description='The immediately following sibling from self',
                           selector=graphene.String())
+    prev = graphene.Field('Element',
+                          description='The immediately preceding sibling from self',
+                          selector=graphene.String())
 
     def _query_selector(self, args):
         selector = args.get('selector')
@@ -80,11 +83,17 @@ class Node(graphene.Interface):
 
     def resolve_siblings(self, args, info):
         selector = args.get('selector')
-        return self.nextAll(selector).items()
+        return self.siblings(selector).items()
 
     def resolve_next(self, args, info):
         selector = args.get('selector')
         n = self.nextAll(selector)
+        if n:
+            return n.eq(0)
+
+    def resolve_prev(self, args, info):
+        selector = args.get('selector')
+        n = self.prevAll(selector)
         if n:
             return n.eq(0)
 


### PR DESCRIPTION
The `next`, `siblings`, `prev` keyword returns the immediately following, siblings and immediately preceding sibling(s) from the current element.

Added also an example for querying HackerNews.
